### PR TITLE
Add more concise mock function for models

### DIFF
--- a/schematics_extensions/models/__init__.py
+++ b/schematics_extensions/models/__init__.py
@@ -4,6 +4,10 @@ from schematics.models import Model
 class Model(Model):
 
     @classmethod
+    def mock(cls, *args, **kwargs):
+        return cls.get_mock_object(overrides=kwargs)
+
+    @classmethod
     def get_null_object(cls, overrides=None):
         if overrides is None:
             overrides = {}


### PR DESCRIPTION
Now instead of doing something like:

    plan = Plan.get_mock_object(overrides={'external_id': external_id})

we can just do

    plan = Plan.mock(external_id=external_id)