### PR TITLE
Add debug field to all Models

### DIFF
--- a/schematics_extensions/mixins.py
+++ b/schematics_extensions/mixins.py
@@ -1,0 +1,19 @@
+from schematics.types import BaseType
+from schematics.transforms import blacklist
+
+from . import MockableDictType as DictType
+from .models import Model
+
+
+class DebugMixin(Model):
+    """Model that has a 'debug' field and a 'debug' role which allows it to be
+    displayed.
+    """
+
+    debug = DictType(BaseType)
+
+    class Options:
+        roles = {
+            'default': blacklist('debug'),
+            'debug': blacklist()
+        }


### PR DESCRIPTION
This makes testing for changes in utility values easier, as the field will always be on the model (and, can be used for any type that inherits from `Model` in the future).