### PR TITLE
Force DebugMixin to have default value

### DIFF
--- a/schematics_extensions/mixins.py
+++ b/schematics_extensions/mixins.py
@@ -10,7 +10,7 @@ class DebugMixin(Model):
     displayed.
     """
 
-    debug = DictType(BaseType)
+    debug = DictType(BaseType, default={})
 
     class Options:
         roles = {


### PR DESCRIPTION
This is necessary so that
- a mock of a model with a debug field doesn't have it occasionally set to `None`
- we can rely on the property being there and assign key/value pairs without checking if the property is set or not