### PR TITLE
Explicity define model __hash__ function

### DIFF
--- a/schematics_extensions/models/__init__.py
+++ b/schematics_extensions/models/__init__.py
@@ -45,3 +45,6 @@ class Model(Model):
 
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self._data)
+
+    def __hash__(self):
+        return id(self)


### PR DESCRIPTION
This is reqired if `Model` objects are to be hashable in Python 3.