### PR TITLE
Fix imports and packages in setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include setup.cfg
+include setup.py
+recursive-include schematics_extensions *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include setup.cfg
 include setup.py
 recursive-include schematics_extensions *
+recursive-exclude schematics_extensions test/*

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,13 @@ requirements = [
     'schematics==1.1.1',
 ]
 
-setup(name='schematics-extensions',
-      version='0.0.5',
-      description='Extensions for the Schematics library',
-      author='Picwell',
-      author_email='dev@picwell.com',
-      url='http://github.com/picwell/schematics-extensions',
-      packages=find_packages(),
-      install_requires=requirements)
+setup(
+    name='schematics-extensions',
+    version='0.0.6',
+    description='Extensions for the Schematics library',
+    author='Picwell',
+    author_email='dev@picwell.com',
+    url='http://github.com/picwell/schematics-extensions',
+    packages=find_packages(),
+    install_requires=requirements
+)

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ setup(
     author_email='dev@picwell.com',
     url='http://github.com/picwell/schematics-extensions',
     packages=find_packages(exclude=['*.test']),
-    install_requires=requirements
+    install_requires=requirements,
+    include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from distutils.core import setup, find_packages
 
 requirements = [
     'schematics==1.1.1',
@@ -12,5 +12,5 @@ setup(name='schematics-extensions',
       author='Picwell',
       author_email='dev@picwell.com',
       url='http://github.com/picwell/schematics-extensions',
-      packages=['schematics_extensions'],
+      packages=find_packages(),
       install_requires=requirements)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup, find_packages
+from setuptools import setup, find_packages
 
 requirements = [
     'schematics==1.1.1',

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
     author='Picwell',
     author_email='dev@picwell.com',
     url='http://github.com/picwell/schematics-extensions',
-    packages=find_packages(),
+    packages=find_packages(exclude=['*.test']),
     install_requires=requirements
 )


### PR DESCRIPTION
This pull request updates the repository's `setup.py` to import from `setuptools` instead of `distutils.core` and use `find_packages` to include all packages (I suppose the inclusion of `test` is up for debate).

This arose as part of MED-2914 where when attempting to install `schematics_extensions` via `pip` from GitHub only the top-level files would be included (i.e. nothing in `schematics_extensions/types` or `schematics_extensions/models`):

```
(venv) trevor@Trevors-MBP ~/p/p/gonzales> tree venv/lib/python2.7/site-packages/schematics_extensions | grep -v .pyc$
venv/lib/python2.7/site-packages/schematics_extensions
├── __init__.py
├── debuggable_model_type.py
├── immutable_model.py
├── mockable_dict_type.py
├── mockable_list_type.py
├── mockable_model_type.py
├── numeric_string_type.py

0 directories, 14 files
```

By using `find_packages`, all the files are included and gonzales starts successfully:

```
venv/lib/python2.7/site-packages/schematics_extensions
├── __init__.py
├── debuggable_model_type.py
├── immutable_model.py
├── mockable_dict_type.py
├── mockable_list_type.py
├── mockable_model_type.py
├── models
│   ├── __init__.py
│   ├── validate.py
├── numeric_string_type.py
├── test
│   ├── __init__.py
│   ├── test_currency_rounding.py
│   ├── test_get_null_object.py
│   ├── test_immutable_model.py
│   ├── test_mockable_dict_type.py
│   ├── test_mockable_list_type.py
│   ├── test_mockable_model.py
│   ├── test_model_repr.py
│   ├── test_numeric_string_type.py
│   ├── test_validation.py
└── types
    ├── __init__.py
    └── compound
        ├── __init__.py

4 directories, 42 files
```